### PR TITLE
Rename OCR endpoint to /img2text for clarity

### DIFF
--- a/src/routers/translations/translations_orc.py
+++ b/src/routers/translations/translations_orc.py
@@ -9,7 +9,7 @@ router = APIRouter(
                500: {"description": "Server error"}},
 )
 
-@router.post("/orc", tags=tags)
+@router.post("/img2text", tags=tags)
 async def image2text(file: UploadFile = File(...)):
     try:
         image_bytes = await file.read()


### PR DESCRIPTION
Update the OCR endpoint to improve clarity by renaming it to /img2text.